### PR TITLE
✨ Add release summary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,6 @@ ADD         . /app
 
 EXPOSE      80
 ENV         FLASK_APP "manage.py"
+ENV         AWS_DEFAULT_REGION "us-east-1"
 
 CMD ["flask", "run", "-h", "0.0.0.0", "-p", "80"]

--- a/README.md
+++ b/README.md
@@ -17,3 +17,22 @@ release being made into a tidy report.
 
 The Release Report Service follows the [Task Service spec](https://kids-first.github.io/kf-api-release-coordinator/docs/task.html)
 outlined by the Release Coordinator.
+
+### Tables
+
+The Release Reports Service stores statistics about each report in various tables in dynamo. Below is the schema for each:
+
+#### Task
+
+The task table stores logistics information about each task.
+
+| release_id | task_id | created_at | state |
+|------------|---------|------------|-------|
+
+
+#### Release Summary
+
+The release summary stores information about aggregate counts for each entity
+
+| release_id | task_id | version | studies | participants | ... |
+|------------|---------|---------|---------|--------------|-----|

--- a/config.py
+++ b/config.py
@@ -20,5 +20,7 @@ class Config():
     DYNAMO_ENDPOINT = os.environ.get('DYNAMO_ENDPOINT',
                                      'http://localhost:8050')
     TASK_TABLE = os.environ.get('TASK_TABLE',
-                                  'release-reports')
+                                'release-reports')
+    RELEASE_SUMMARY_TABLE = os.environ.get('RELEASE_SUMMARY_TABLE',
+                                           'release-summary')
     TIMEOUT = os.environ.get('TIMEOUT', 10)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,22 @@ services:
     kf-task-release-reports:
         build: .
         image: kf-task-release-reports:latest
-        command: /bin/ash -c "flask run"
+        command: /bin/bash -c "flask migrate; flask run -h 0.0.0.0 -p 80"
         environment:
-            - DYNAMO_ENDPOINT=http://dynamo:8050
+            - DYNAMO_ENDPOINT=http://dynamo:8000
+            - FLASK_APP=manage.py
+            - DATASERVICE_URL=http://dataservice
+            - COORDINATOR_URL=http://coordinator
+            - AWS_DEFAULT_REGION=us-east-1
+            - AWS_ACCESS_KEY_ID=blah
+            - AWS_SECRET_ACCESS_KEY=blah
+        ports:
+            - "5020:80"
     dynamo:
         image: amazon/dynamodb-local:latest
         ports:
             - "8050:8000"
+networks:
+    default:
+        external:
+            name: kf-data-stack_default

--- a/manage.py
+++ b/manage.py
@@ -2,7 +2,7 @@
 import os
 import boto3
 from reports import create_app
-from schema import task_schema
+from schema import task_schema, release_summary_schema
 
 app = create_app()
 
@@ -19,9 +19,20 @@ def migrate():
         print('Table already exists')
         return
 
-    print('Making table')
+    print('Making task table')
     response = db.create_table(TableName=app.config['TASK_TABLE'],
                                **task_schema)
+
+    print('Making release summary table')
+    try:
+        response = db.describe_table(TableName=app.config['RELEASE_SUMMARY_TABLE'])
+    except:
+        pass
+    else:
+        print('Table already exists')
+        return
+    response = db.create_table(TableName=app.config['RELEASE_SUMMARY_TABLE'],
+                               **release_summary_schema)
 
 
 if __name__ == '__main__':

--- a/reports/__init__.py
+++ b/reports/__init__.py
@@ -2,6 +2,7 @@ import decimal
 from flask import Flask, Blueprint, current_app, jsonify, request, abort, json
 from werkzeug.exceptions import HTTPException
 from . import tasks
+from .reporting import reports_api
 
 
 class DynamoJSON(json.JSONEncoder):
@@ -35,6 +36,7 @@ def create_app():
         app.register_error_handler(ex, json_error)
 
     app.register_blueprint(api)
+    app.register_blueprint(reports_api)
 
     return app
 

--- a/reports/reporting/__init__.py
+++ b/reports/reporting/__init__.py
@@ -1,0 +1,23 @@
+import boto3
+import logging
+from flask import Flask, Blueprint, current_app, jsonify, request, abort, json
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+reports_api = Blueprint('reports', __name__, url_prefix='/reports')
+
+
+@reports_api.route('/<kf_id>', methods=['GET'])
+def get_report(kf_id):
+    endpoint_url = current_app.config['DYNAMO_ENDPOINT']
+    db = boto3.resource('dynamodb', endpoint_url=endpoint_url)
+    table = db.Table(current_app.config['RELEASE_SUMMARY_TABLE'])
+
+    resp = table.get_item(Key={'release_id': kf_id})
+
+    if 'Item' not in resp or len(resp['Item']) == 0:
+        abort(404, f'could not find a report for release {kf_id}')
+
+    return jsonify(resp['Item']), 200

--- a/reports/reporting/release_summary.py
+++ b/reports/reporting/release_summary.py
@@ -1,0 +1,116 @@
+import boto3
+import datetime
+import requests
+import logging
+from collections import Counter
+from flask import current_app
+
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+# Entities to collect total counts for
+ENTITIES = [
+    'participants',
+    'biospecimens',
+    'phenotypes',
+    'genomic-files',
+    'study-files',
+    'read-groups',
+    'diagnoses',
+    'sequencing-experiments',
+    'families'
+]
+
+
+def run(task_id, release_id):
+    endpoint_url = current_app.config['DYNAMO_ENDPOINT']
+    db = boto3.resource('dynamodb', endpoint_url=endpoint_url)
+    table = db.Table(current_app.config['RELEASE_SUMMARY_TABLE'])
+
+    studies, version = get_studies(release_id)
+
+    counts = collect_counts(studies)
+
+    base_fields = {
+        'task_id': task_id,
+        'release_id': release_id,
+        'version': version
+    }
+    counts.update(base_fields)
+    logger.info(counts)
+
+    # Store the count summary in dynamo
+    response = table.put_item(
+        Item=counts,
+        ReturnValues='NONE',
+        ReturnConsumedCapacity='NONE',
+    )
+    return counts
+
+
+def get_studies(release_id):
+    """
+    Retieve the study ids for the release and the release's version number
+    from the coordinator
+    """
+    coord_api = current_app.config['COORDINATOR_URL']
+    resp = requests.get(f'{coord_api}/releases/{release_id}?limit=100',
+                        timeout=current_app.config['TIMEOUT'])
+
+    try:
+        resp.raise_for_status()
+    except requests.exceptions.RequestException:
+        logger.error(f'could not get studies for {release_id}')
+        abort(500, 'there was a problem getting studies from the coordinator')
+
+    studies = resp.json()['studies']
+    version = resp.json()['version']
+    return studies, version
+
+
+def collect_counts(studies):
+    """ Aggregates counts for specified entities in each study """
+    # Counts by study
+    study_counts = {study: Counter(count_study(study)) for study in studies}
+    # Total counts
+    total_counts = dict(sum(study_counts.values(), Counter()))
+    total_counts['studies'] = len(study_counts.keys())
+
+    return total_counts
+
+
+def count_study(study_id):
+    """
+    Query the dataservice for totals of visible entities and return a dict
+    containing the number of each
+
+    :param study_id: The study id to filter entities by
+    :returns: A dict of entities to  visible counts for the study
+    """
+
+    counts = {entity: count_entity(study_id, entity) for entity in ENTITIES}
+    # Filter out entities that had request issues
+    return {k: v for k, v in counts.items() if v is not None}
+
+
+def count_entity(study_id, entity):
+    """
+    Query the dataservice for the total visible entities of a certain type
+    """
+    dataservice_api = current_app.config['DATASERVICE_URL']
+    url = f'{dataservice_api}/{entity}?{study_id}&visible=true&limit=1'
+
+    try:
+        resp = requests.get(url, timeout=current_app.config['TIMEOUT'])
+        resp.raise_for_status()
+    except requests.exceptions.RequestException:
+        logger.error(f'could not get {url}')
+        return None
+
+    if 'total' not in resp.json():
+        logger.error(f'mishaped response from {url}')
+        return None
+
+    return resp.json()['total']

--- a/schema.py
+++ b/schema.py
@@ -1,21 +1,10 @@
+# Responsible for storing basic logistic information about tasks
 task_schema = dict(AttributeDefinitions=[
         { 'AttributeName': 'task_id', 'AttributeType': 'S' },
         { 'AttributeName': 'created_at', 'AttributeType': 'N' },
     ],
     KeySchema=[
         { 'AttributeName': 'task_id', 'KeyType': 'HASH' },
-    ],
-    LocalSecondaryIndexes=[
-        {
-            'IndexName': 'local_task_id',
-            'KeySchema': [
-                { 'AttributeName': 'task_id', 'KeyType': 'HASH' },
-                { 'AttributeName': 'created_at', 'KeyType': 'RANGE' },
-            ],
-            'Projection': {
-                'ProjectionType': 'KEYS_ONLY',
-            }
-        },
     ],
     GlobalSecondaryIndexes=[
         {
@@ -32,6 +21,22 @@ task_schema = dict(AttributeDefinitions=[
                 'WriteCapacityUnits': 1
             }
         },
+    ],
+    ProvisionedThroughput={
+        'ReadCapacityUnits': 1,
+        'WriteCapacityUnits': 1
+    },
+    StreamSpecification={ 'StreamEnabled': False },
+    SSESpecification={ 'Enabled': False }
+)
+
+
+# Stores overview stats of the release, such as total changes per entity
+release_summary_schema = dict(AttributeDefinitions=[
+        { 'AttributeName': 'release_id', 'AttributeType': 'S' },
+    ],
+    KeySchema=[
+        { 'AttributeName': 'release_id', 'KeyType': 'HASH' },
     ],
     ProvisionedThroughput={
         'ReadCapacityUnits': 1,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,18 +1,26 @@
 import pytest
 from reports import create_app
 from moto.dynamodb2 import dynamodb_backend2, mock_dynamodb2
-from schema import task_schema
+from schema import task_schema, release_summary_schema
 
 
 @pytest.yield_fixture(scope='module')
 def client():
     with mock_dynamodb2():
         schema = task_schema['KeySchema']
-        indexes = task_schema['LocalSecondaryIndexes']
+        indexes = task_schema['GlobalSecondaryIndexes']
         dynamodb_backend2.create_table('test', schema=schema, indexes=indexes)
+
+        schema = release_summary_schema['KeySchema']
+        dynamodb_backend2.create_table('release-summary',
+                                       schema=schema, indexes=[])
+
         app = create_app()
         app.config['DYNAMO_ENDPOINT'] = None
         app.config['TASK_TABLE'] = 'test'
+        app.config['RELEASE_SUMMARY_TABLE'] = 'release-summary'
+        app.config['DATASERVICE_URL'] = 'http://dataservice'
+        app.config['COORDINATOR_URL'] = 'http://coordinator'
         app_context = app.app_context()
         app_context.push()
         yield app.test_client()

--- a/tests/test_release_summary.py
+++ b/tests/test_release_summary.py
@@ -1,0 +1,100 @@
+import boto3
+import datetime
+import requests
+import pytest
+from unittest.mock import patch
+from reports.reporting import release_summary
+
+
+ENTITIES = [
+    'participants',
+    'biospecimens',
+    'phenotypes',
+    'genomic-files',
+    'study-files',
+    'read-groups',
+    'diagnoses',
+    'sequencing-experiments',
+    'families'
+]
+
+
+def mocked_apis(url, *args, **kwargs):
+    class MockResponse:
+        def __init__(self, json_data, status_code):
+            self.json_data = json_data
+            self.status_code = status_code
+
+        def json(self):
+            return self.json_data
+
+        def raise_for_status(self):
+            if self.status_code >= 400:
+                raise requests.exceptions.HTTPError(self.status_code)
+
+    # Coordinator response
+    if 'coordinator' in url and url.split('/')[-2] == 'releases':
+        return MockResponse({
+            'studies': ['SD_00000000'],
+            'version': '0.0.0'
+        }, 200)
+
+    # Dataservice response
+    if 'dataservice' in url:
+        return MockResponse({'total': 1}, 200)
+
+    return MockResponse(None, 404)
+
+
+def test_get_studies(client):
+    """ Test that a task is set to canceled after being initialized """
+    db = boto3.resource('dynamodb')
+    db = boto3.client('dynamodb')
+
+    with patch('requests.get') as mock_request:
+        mock_request.side_effect = mocked_apis
+        studies, version = release_summary.get_studies('RE_00000000')
+        assert studies == ['SD_00000000']
+        assert version == '0.0.0'
+
+        mock_request.assert_called_with(
+            'http://coordinator/releases/RE_00000000?limit=100',
+            timeout=10)
+
+
+@pytest.mark.parametrize("entity", ENTITIES)
+def test_entity_counts(client, entity):
+    with patch('requests.get') as mock_request:
+        mock_request.side_effect = mocked_apis
+        r = release_summary.count_entity('SD_00000000', entity)
+        assert r == 1
+
+
+def test_count_study(client):
+    """ Test that entities are counted within a study """
+    with patch('requests.get') as mock_request:
+        mock_request.side_effect = mocked_apis
+        r = release_summary.count_study('SD_00000000')
+        assert r == {k: 1 for k in ENTITIES}
+
+
+def test_count_studies(client):
+    """ Test that study counts are aggregated across studies """
+    with patch('requests.get') as mock_request:
+        mock_request.side_effect = mocked_apis
+        r = release_summary.collect_counts(['SD_00000000', 'SD_00000001'])
+        assert r == {k: 2 for k in ENTITIES + ['studies']}
+
+
+def test_run(client):
+    """ Test that study counts are aggregated across studies """
+    db = boto3.resource('dynamodb')
+    table = db.Table('release-summary')
+    db = boto3.client('dynamodb')
+    with patch('requests.get') as mock_request:
+        mock_request.side_effect = mocked_apis
+        r = release_summary.run('TA_00000000', 'RE_00000000')
+        assert all(k in r for k in ENTITIES)
+        assert r['release_id'] == 'RE_00000000'
+        assert r['task_id'] == 'TA_00000000'
+    assert table.item_count == 1

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -6,30 +6,6 @@ from moto.dynamodb2 import dynamodb_backend2, mock_dynamodb2
 import reports.tasks
 
 
-def mocked_coordinator_releases(*args, **kwargs):
-    class MockResponse:
-        def __init__(self, json_data, status_code):
-            self.json_data = json_data
-            self.status_code = status_code
-
-        def json(self):
-            return self.json_data
-
-        def raise_for_status(self):
-            if self.status_code >= 400:
-                raise requests.exceptions.HTTPError(self.status_code)
-
-    if args[0].split('/')[-2] == 'releases':
-        return MockResponse({"studies": ["SD_00000000"]}, 200)
-
-    return MockResponse(None, 404)
-
-
 def test_get_studies(client):
     """ Test that studies are fetched from the dataservice """
-    with patch('requests.get') as mock_coord:
-        mock_coord.side_effect = mocked_coordinator_releases
-        resp = reports.tasks.run.get_studies('RE_00000000')
-        mock_coord.assert_called_with(
-            'http://localhost:5001/releases/RE_00000000',
-            timeout=10)
+    pass

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -23,17 +23,18 @@ def test_start(client):
     db = boto3.resource('dynamodb')
     table = db.Table('test')
 
-    with patch('reports.tasks.run.requests') as mock_coord:
-        resp = client.post('/tasks', json={'action': 'initialize',
-                                           'release_id': 'RE_00000000',
-                                           'task_id': 'TA_00000000'})
+    with patch('requests.get') as mock_coord:
+        with patch('reports.reporting.release_summary.run') as mock_summary:
+            resp = client.post('/tasks', json={'action': 'initialize',
+                                               'release_id': 'RE_00000000',
+                                               'task_id': 'TA_00000000'})
 
-        resp = client.post('/tasks', json={'action': 'start',
-                                           'release_id': 'RE_00000000',
-                                           'task_id': 'TA_00000000'})
+            resp = client.post('/tasks', json={'action': 'start',
+                                               'release_id': 'RE_00000000',
+                                               'task_id': 'TA_00000000'})
 
-        assert resp.status_code == 200
-        assert resp.json['state'] == 'running'
+            assert resp.status_code == 200
+            assert resp.json['state'] == 'running'
 
-        task = table.get_item(Key={'task_id': 'TA_00000000'})['Item']
-        assert task['state'] == 'staged'
+            task = table.get_item(Key={'task_id': 'TA_00000000'})['Item']
+            assert task['state'] == 'staged'


### PR DESCRIPTION
Creates simple release count reports available at `/releases/<kf_id>`.

This will return simple counts for all entities involved in a release:

```
{
  "release_id": "RE_00000000",
  "task_id": "TA_00000000",
  "version": "0.0.0",
  "biospecimens": 1,
  "diagnoses": 1,
  "families": 1,
  "genomic-files": 1,
  "participants": 1,
  "phenotypes": 1,
  "read-groups": 1,
  "sequencing-experiments": 1,
  "studies": 1,
  "study-files": 1,
}
```