### PR TITLE
✨ Update state and version of summary rows upon publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ The task table stores logistics information about each task.
 
 The release summary stores information about aggregate counts for each entity
 
-| release_id | task_id | created_at | version | studies | participants | ... |
-|------------|---------|------------|---------|---------|--------------|-----|
+| release_id | task_id | created_at | version | state | studies | participants | ... |
+|------------|---------|------------|---------|-------|---------|--------------|-----|
 
 
 #### Study Summary
 
 The study summary stores information about aggregate counts for each entity for a given study in a given release.
 
-| study_id | release_id| release_id | task_id | created_at | version | participants | ... |
-|----------|-----------|------------|---------|------------|---------|--------------|-----|
+| study_id | release_id| release_id | task_id | created_at | version | state | participants | ... |
+|----------|-----------|------------|---------|------------|---------|-------|--------------|-----|

--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -72,6 +72,10 @@ definitions:
         type: "string"
         format: "string"
         example: "0.0.1"
+      state:
+        type: "string"
+        format: "string"
+        example: "staged"
       created_at:
         type: "string"
         format: "date"
@@ -114,6 +118,10 @@ definitions:
         type: "string"
         format: "string"
         example: "0.0.1"
+      state:
+        type: "string"
+        format: "string"
+        example: "staged"
       studies:
         type: "integer"
         format: "integer"

--- a/reports/tasks/publish.py
+++ b/reports/tasks/publish.py
@@ -3,6 +3,7 @@ import logging
 from flask import current_app, abort, jsonify
 from zappa.async import task
 from reports.tasks.validation import validate_state
+from reports.reporting import release_summary
 
 
 logger = logging.getLogger()
@@ -70,5 +71,8 @@ def publish_in_context(task_id, release_id):
     if 'Attributes' not in task or len(task['Attributes']) == 0:
         logger.error(f"problem updating task '{task_id}'")
         return abort(500, f"problem updating '{task_id}'")
+
+    # Finally, update the summary rows with new state and version
+    release_summary.publish(release_id)
 
     return jsonify(task['Attributes']), 200

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -17,16 +17,18 @@ def test_not_found(client):
     assert 'a task that does not exist' in resp.json['message']
 
 
-def test_publish(client):
+def test_publish(client, mocked_apis):
     """ Test that a task's state is updated to 'published' """
     db = boto3.resource('dynamodb')
     table = db.Table('test')
 
     _make_task('staged')
 
-    resp = client.post('/tasks', json={'action': 'publish',
-                                       'release_id': 'RE_00000000',
-                                       'task_id': 'TA_00000000'})
+    with patch('requests.get') as mock_request:
+        mock_request.side_effect = mocked_apis
+        resp = client.post('/tasks', json={'action': 'publish',
+                                           'release_id': 'RE_00000000',
+                                           'task_id': 'TA_00000000'})
 
     # API should respond with publish, but task should be published in db
     assert resp.status_code == 200

--- a/tests/test_release_summary.py
+++ b/tests/test_release_summary.py
@@ -5,6 +5,7 @@ import pytest
 from unittest.mock import patch
 from reports.reporting import release_summary
 from collections import Counter
+from functools import partial
 
 
 ENTITIES = [
@@ -36,8 +37,9 @@ def mocked_apis(url, *args, **kwargs):
     # Coordinator response
     if 'coordinator' in url and url.split('/')[-2] == 'releases':
         return MockResponse({
-            'studies': ['SD_00000000'],
-            'version': '0.0.0'
+            'studies': kwargs.get('studies', ['SD_00000000']),
+            'version': kwargs.get('version', '0.0.0'),
+            'state': kwargs.get('state', 'staged')
         }, 200)
 
     # Dataservice response
@@ -54,9 +56,10 @@ def test_get_studies(client):
 
     with patch('requests.get') as mock_request:
         mock_request.side_effect = mocked_apis
-        studies, version = release_summary.get_studies('RE_00000000')
+        studies, version, state = release_summary.get_studies('RE_00000000')
         assert studies == ['SD_00000000']
         assert version == '0.0.0'
+        assert state == 'staged'
 
         mock_request.assert_called_with(
             'http://coordinator/releases/RE_00000000?limit=100',
@@ -109,6 +112,7 @@ def test_run(client):
     })['Item']
     assert st['study_id'] == 'SD_00000000'
     assert st['version'] == '0.0.0'
+    assert st['state'] == 'staged'
     assert all(st[k] == 1 for k in ENTITIES)
 
 
@@ -135,3 +139,78 @@ def test_report_not_found(client):
 
     assert resp.status_code == 404
     assert 'could not find a report for release RE_' in resp.json['message']
+
+
+def test_publish(client):
+    """ Test that release and study summary rows are updated upon publish """
+    db = boto3.resource('dynamodb')
+    release_table = db.Table('release-summary')
+    study_table = db.Table('study-summary')
+
+    def _test_summaries(state, version):
+        assert release_table.item_count == 1
+        re = release_table.get_item(Key={
+            'release_id': 'RE_00000000',
+            'study_id': 'SD_00000000'
+        })['Item']
+        assert re['release_id'] == 'RE_00000000'
+        assert re['version'] == version
+        assert re['state'] == state
+
+        assert study_table.item_count == 1
+        st = study_table.get_item(Key={
+            'release_id': 'RE_00000000',
+            'study_id': 'SD_00000000'
+        })['Item']
+        assert st['study_id'] == 'SD_00000000'
+        assert st['version'] == version
+        assert st['state'] == state
+        assert all(st[k] == 1 for k in ENTITIES)
+
+    with patch('requests.get') as mock_request:
+        # The release has been run as candidate release 0.0.3
+        mock_request.side_effect = partial(mocked_apis, version='0.0.3')
+        r = release_summary.run('TA_00000000', 'RE_00000000')
+
+        _test_summaries('staged', '0.0.3')
+
+        # Now the release has been published and its version number bumped
+        # in the coordinator to 0.1.0
+        mock_request.side_effect = partial(mocked_apis, version='0.1.0')
+        r = release_summary.publish('RE_00000000')
+
+        _test_summaries('published', '0.1.0')
+
+
+def test_publish_does_not_exist(client):
+    """
+    Test behavior if a release is published and one of the summary rows
+    do not exist
+    """
+    db = boto3.resource('dynamodb')
+    release_table = db.Table('release-summary')
+    study_table = db.Table('study-summary')
+
+    with patch('requests.get') as mock_request:
+        mock_request.side_effect = partial(mocked_apis, version='0.0.3')
+        r = release_summary.run('TA_00000000', 'RE_00000000')
+
+        assert release_table.item_count == 1
+        assert study_table.item_count == 1
+        # Now delete the summaries, as if it never existed
+        release_table.delete_item(Key={
+            'release_id': 'RE_00000000'
+        })
+        study_table.delete_item(Key={
+            'release_id': 'RE_00000000',
+            'study_id': 'SD_00000000'
+        })
+        assert release_table.item_count == 0
+        assert study_table.item_count == 0
+
+        # Publish the release
+        mock_request.side_effect = partial(mocked_apis, version='0.1.0')
+        r = release_summary.publish('RE_00000000')
+        # There should still be no summary rows
+        assert release_table.item_count == 0
+        assert study_table.item_count == 0


### PR DESCRIPTION
Upon task publish, summary rows should be updated with the `published` task state and the new version number.

Closes #23 
Closes #24 