### PR TITLE
🔧 Add CORS header to responses

### DIFF
--- a/reports/__init__.py
+++ b/reports/__init__.py
@@ -43,6 +43,7 @@ def create_app():
     @app.after_request
     def after_request(response):
         response.headers.add('Access-Control-Allow-Origin', '*')
+        response.headers.add('Access-Control-Allow-Headers', 'authorization')
         return response
 
     return app

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,3 +8,9 @@ def test_status(client):
     assert resp.status_code == 200
     assert 'name' in json.loads(resp.data.decode())
     assert 'version' in json.loads(resp.data.decode())
+
+
+def test_headers(client):
+    resp = client.get('/status')
+    assert 'Access-Control-Allow-Headers' in resp.headers
+    assert 'Access-Control-Allow-Origin' in resp.headers


### PR DESCRIPTION
Adds `Access-Control-Allow-Headers` to response headers to allow `Authorization` to be sent from the browser.

Fixes #32 